### PR TITLE
定石の長さの最大値を設定

### DIFF
--- a/backend/controller/joseki.go
+++ b/backend/controller/joseki.go
@@ -12,10 +12,10 @@ import (
 func GetVideoHandler(c echo.Context) error {
 	var request model.VideoGetRequest
 	if err := c.Bind(&request); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	if err := c.Validate(&request); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	videos := service.GetVideos(request)
 	var data model.VideoResponse
@@ -34,13 +34,13 @@ func GetVideoHandler(c echo.Context) error {
 func GetRankingHandler(c echo.Context) error {
 	limit, err := strconv.Atoi(c.QueryParam("limit"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	if limit <= 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, "value 'limit' must be greater than 0")
+		return echo.NewHTTPError(http.StatusInternalServerError, "value 'limit' must be greater than 0")
 	}
 	if limit >= 100 {
-		return echo.NewHTTPError(http.StatusBadRequest, "value 'limit' must be less than 100")
+		return echo.NewHTTPError(http.StatusInternalServerError, "value 'limit' must be less than 100")
 	}
 	res := service.GetRanking(limit)
 	data := model.RankingResponse{
@@ -52,19 +52,24 @@ func GetRankingHandler(c echo.Context) error {
 func PostJosekiHandler(c echo.Context) error {
 	var request model.JosekiPostRequest
 	if err := c.Bind(&request); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	if err := c.Validate(&request); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	if len(request.Joseki.Stones) == 0 {
-		return c.JSON(http.StatusBadRequest, model.ErrorResponse{
+		return c.JSON(http.StatusInternalServerError, model.ErrorResponse{
 			Message: "At least 1 stones are required",
 		})
 	}
 	if len(request.Joseki.Stones) > 30 {
-		return c.JSON(http.StatusBadRequest, model.ErrorResponse{
+		return c.JSON(http.StatusInternalServerError, model.ErrorResponse{
 			Message: "More than 30 stones are not allowed",
+		})
+	}
+	if len(service.GetJoseki(request.Video.Id)) >= 5 {
+		return c.JSON(http.StatusInternalServerError, model.ErrorResponse{
+			Message: "More than 5 videos are not allowed",
 		})
 	}
 	service.PostJoseki(request.Joseki, request.Video)
@@ -93,10 +98,10 @@ func GetJosekiHandler(c echo.Context) error {
 func DeleteJosekiHandler(c echo.Context) error {
 	var request model.JosekiPostRequest
 	if err := c.Bind(&request); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	if err := c.Validate(&request); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	println("DeleteJosekiHandler called with request:", request.Video.Id)
 	service.DeleteJoseki(request.Joseki, request.Video)

--- a/backend/controller/joseki_test.go
+++ b/backend/controller/joseki_test.go
@@ -97,7 +97,7 @@ func TestPostJosekiEmpty(t *testing.T) {
 
 	// Assertions
 	if assert.NoError(t, controller.PostJosekiHandler(c)) {
-		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
 		assert.Equal(t, ResponsePostJosekiEmptyJSON, rec.Body.String())
 	}
 }

--- a/backend/validator/validator.go
+++ b/backend/validator/validator.go
@@ -13,7 +13,7 @@ type CustomValidator struct {
 
 func (cv *CustomValidator) Validate(i interface{}) error {
 	if err := cv.Validator.Struct(i); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return nil
 }

--- a/web/src/components/VideoList/VideoListItem/SheetItem/GobanPagination/index.tsx
+++ b/web/src/components/VideoList/VideoListItem/SheetItem/GobanPagination/index.tsx
@@ -81,7 +81,7 @@ const GobanPagination: FC<Props> = ({ videoId }) => {
           <Button
             onClick={onStartAdding}
             className="grow"
-            disabled={josekiList.length === 5 || loading}
+            disabled={josekiList.length >= 5 || loading}
           >
             定石を新規追加
           </Button>


### PR DESCRIPTION
- ひとつの動画に関連づけられる定石の個数を5個に制限
- バックエンドのエラーの種類を 500 に統一