### PR TITLE
両ガカリのバグを修正

### DIFF
--- a/backend/controller/joseki.go
+++ b/backend/controller/joseki.go
@@ -103,7 +103,6 @@ func DeleteJosekiHandler(c echo.Context) error {
 	if err := c.Validate(&request); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
-	println("DeleteJosekiHandler called with request:", request.Video.Id)
 	service.DeleteJoseki(request.Joseki, request.Video)
 	return c.JSON(http.StatusOK, model.MessageResponse{
 		Message: "Joseki deleted",

--- a/backend/db/convert.go
+++ b/backend/db/convert.go
@@ -48,6 +48,8 @@ func convertToJoseki(res *neo4j.EagerResult) model.Joseki {
 
 func convertToPathMap(joseki model.Joseki) []map[string]any {
 	var result []map[string]any
+
+	// 先頭ノードはデータベース上にのみ存在する
 	prev := model.Stone{X: -1, Y: -1, Color: -1, Hash: 0}
 	for _, stone := range joseki.Stones {
 		result = append(result, map[string]any{

--- a/backend/model/api.go
+++ b/backend/model/api.go
@@ -34,8 +34,8 @@ type RankingData struct {
 
 type StoneData struct {
 	Color *int `json:"color" validate:"required,oneof=0 1"`
-	X     *int `json:"x" validate:"required,min=-1,max=18"`
-	Y     *int `json:"y" validate:"required,min=-1,max=18"`
+	X     *int `json:"x" validate:"required,min=0,max=18"`
+	Y     *int `json:"y" validate:"required,min=0,max=18"`
 }
 
 type JosekiData struct {

--- a/backend/util/joseki_hash.go
+++ b/backend/util/joseki_hash.go
@@ -28,9 +28,7 @@ func JosekiHash(joseki *model.Joseki) {
 	stones := &((*joseki).Stones)
 	val := int64(0)
 	for i := range *stones {
-		if (*stones)[i].X == -1 && (*stones)[i].Y == -1 {
-			val = val ^ table[model.BoardSize][model.BoardSize][i]
-		} else if (*stones)[i].Color == model.Black {
+		if (*stones)[i].Color == model.Black {
 			val = val ^ table[(*stones)[i].X][(*stones)[i].Y][i]
 		} else {
 			val = val ^ table[(*stones)[i].X][(*stones)[i].Y][i+model.All]

--- a/backend/util/joseki_normalization.go
+++ b/backend/util/joseki_normalization.go
@@ -1,26 +1,59 @@
 package util
 
-import "github.com/usatyo/sugomori/model"
+import (
+	"slices"
+
+	"github.com/usatyo/sugomori/model"
+)
 
 // 向き・白黒を正規化（辞書順）
 // 最初の手抜きを削除
 
 func GetNormalizedJoseki(joseki model.Joseki) model.Joseki {
-	joseki = removeFirstPass(joseki)
-	var options []model.Joseki = []model.Joseki{
-		joseki,
-		getReversedJoseki(joseki),
-		getSymmetricJoseki(joseki),
-		getReversedJoseki(getSymmetricJoseki(joseki)),
+	if len(joseki.Stones) == 0 {
+		return joseki
 	}
-	var minJoseki model.Joseki = joseki
-	for _, option := range options {
-		minJoseki = min(minJoseki, option)
-		minJoseki = min(minJoseki, getRotatedJoseki(option))
-		minJoseki = min(minJoseki, getRotatedJoseki(getRotatedJoseki(option)))
-		minJoseki = min(minJoseki, getRotatedJoseki(getRotatedJoseki(getRotatedJoseki(option))))
+	if joseki.Stones[0].Color == model.White {
+		joseki = getReversedJoseki(joseki)
 	}
-	return minJoseki
+
+	for variant := range 8 {
+		joseki = min(joseki, GetVariousJoseki(joseki, variant))
+	}
+
+	for i := range len(joseki.Stones) {
+		if isSymmetric(joseki.Stones[:i+1]) {
+			originalJoseki := model.Joseki{Stones: joseki.Stones[i+1:]}
+			backJoseki := min(originalJoseki, getSymmetricJoseki(originalJoseki))
+			joseki = model.Joseki{
+				Stones: append(joseki.Stones[:i+1], backJoseki.Stones...),
+			}
+		}
+	}
+	
+	return joseki
+}
+
+func isSymmetric(stones []model.Stone) bool {
+	for _, stone := range stones {
+		if stone.X == stone.Y {
+			continue
+		}
+		if !slices.Contains(stones, model.Stone{Color: stone.Color, X: stone.Y, Y: stone.X}) {
+			return false
+		}
+	}
+	return true
+}
+
+func GetVariousJoseki(joseki model.Joseki, variant int) model.Joseki {
+	if variant < 4 {
+		joseki = getSymmetricJoseki(joseki)
+	}
+	for range variant % 4 {
+		joseki = getRotatedJoseki(joseki)
+	}
+	return joseki
 }
 
 func getSymmetricJoseki(joseki model.Joseki) model.Joseki {
@@ -94,17 +127,4 @@ func toArray(joseki model.Joseki) []int {
 		array = append(array, int(stone.Color), int(stone.X), int(stone.Y))
 	}
 	return array
-}
-
-func removeFirstPass(joseki model.Joseki) model.Joseki {
-	var stones []model.Stone
-	for _, stone := range joseki.Stones {
-		if stone.X == -1 && stone.Y == -1 {
-			continue
-		}
-		stones = append(stones, stone)
-	}
-	return model.Joseki{
-		Stones: stones,
-	}
 }

--- a/backend/util/joseki_normalization_test.go
+++ b/backend/util/joseki_normalization_test.go
@@ -33,36 +33,6 @@ func generateSymmetricStones(random *rand.Rand) ([]model.Stone, []model.Stone) {
 	return stones1, stones2
 }
 
-func generateSkippedStones(random *rand.Rand) ([]model.Stone, []model.Stone) {
-	n := random.Intn(30) + 1
-	stones1 := make([]model.Stone, n)
-	stones2 := make([]model.Stone, n+1)
-	stones2[0] = model.Stone{
-		X:     -1,
-		Y:     -1,
-		Color: model.Color(random.Intn(2)),
-		Hash:  0,
-	}
-	for i := range n {
-		x := random.Intn(model.BoardSize)
-		y := random.Intn(model.BoardSize)
-		color := model.Color(random.Intn(2))
-		stones1[i] = model.Stone{
-			X:     x,
-			Y:     y,
-			Color: color,
-			Hash:  0,
-		}
-		stones2[i+1] = model.Stone{
-			X:     x,
-			Y:     y, // Skip one row
-			Color: model.InversedColor(color),
-			Hash:  0,
-		}
-	}
-	return stones1, stones2
-}
-
 func TestSymmetric(t *testing.T) {
 	random := rand.New(rand.NewSource(0))
 	for range 10000 {
@@ -82,21 +52,21 @@ func TestSymmetric(t *testing.T) {
 	}
 }
 
-func TestSkipped(t *testing.T) {
-	random := rand.New(rand.NewSource(0))
-	for range 10000 {
-		stones1, stones2 := generateSkippedStones(random)
-		joseki1 := model.Joseki{
-			Stones: stones1,
-		}
-		joseki2 := model.Joseki{
-			Stones: stones2,
-		}
+func TestSymmetricInTheMiddle(t *testing.T) {
+	stones := []model.Stone{
+		{X: 3, Y: 3, Color: model.Black},
+		{X: 2, Y: 5, Color: model.White},
+		{X: 5, Y: 2, Color: model.White},
+		{X: 5, Y: 3, Color: model.Black},
+	}
+	joseki1 := model.Joseki{
+		Stones: stones,
+	}
+	util.JosekiHash(&joseki1)
 
-		util.JosekiHash(&joseki1)
+	for variant := range 8 {
+		joseki2 := util.GetVariousJoseki(joseki1, variant)
 		util.JosekiHash(&joseki2)
-
-		// Assertions
 		assert.Equal(t, joseki1.Stones[len(joseki1.Stones)-1].Hash, joseki2.Stones[len(joseki2.Stones)-1].Hash)
 	}
 }

--- a/web/src/components/VideoList/VideoListItem/SheetItem/GobanPagination/index.tsx
+++ b/web/src/components/VideoList/VideoListItem/SheetItem/GobanPagination/index.tsx
@@ -106,7 +106,7 @@ const GobanPagination: FC<Props> = ({ videoId }) => {
                     className="grow bg-destructive text-white hover:bg-destructive/90"
                     onClick={onDeleteJoseki}
                   >
-                    削除します
+                    削除する
                   </AlertDialogAction>
                 </div>
               </AlertDialogContent>


### PR DESCRIPTION
related #52

- バックエンドで基本 `{X: -1, Y: -1}` のデータを扱わないように変更
- 途中で対称な形が出てくる手順に対応できるよう、正規化部分を修正
- 削除確定ボタンの文言を変更